### PR TITLE
fix: prettier & local storage setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@tutorialkit/react": "1.1.1",
+        "prettier": "^3.3.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -8220,7 +8221,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,16 @@
       "name": "tutorialkit-nextjs",
       "version": "0.0.1",
       "dependencies": {
-        "@tutorialkit/react": "1.0.0",
+        "@tutorialkit/react": "1.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@astrojs/check": "^0.7.0",
         "@astrojs/react": "^3.6.0",
-        "@tutorialkit/astro": "1.0.0",
-        "@tutorialkit/theme": "1.0.0",
-        "@tutorialkit/types": "1.0.0",
+        "@tutorialkit/astro": "1.1.1",
+        "@tutorialkit/theme": "1.1.1",
+        "@tutorialkit/types": "1.1.1",
         "@types/node": "^20.14.6",
         "@types/react": "^18.3.3",
         "astro": "^4.15.0",
@@ -256,12 +256,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
-      "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
+      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.24.7",
+        "@babel/highlight": "^7.25.7",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -308,27 +308,27 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
-      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
+      "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6",
+        "@babel/types": "^7.25.7",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
-        "jsesc": "^2.5.1"
+        "jsesc": "^3.0.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
-      "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.7.tgz",
+      "integrity": "sha512-4xwU8StnqnlIhhioZf1tqnVWeQ9pvH/ujS8hRfw/WOza+/a+1qv69BWNy+oY231maTCWgKWhfBU7kDpsds6zAA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -351,17 +351,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
-      "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.7.tgz",
+      "integrity": "sha512-bD4WQhbkx80mAyj/WCm4ZHcF4rDxkoLFO6ph8/5/mQ3z4vAzltQXAmbc7GvVJx5H+lk5Mi5EmbTeox5nMGCsbw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-member-expression-to-functions": "^7.24.8",
-        "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/helper-replace-supers": "^7.25.0",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/traverse": "^7.25.4",
+        "@babel/helper-annotate-as-pure": "^7.25.7",
+        "@babel/helper-member-expression-to-functions": "^7.25.7",
+        "@babel/helper-optimise-call-expression": "^7.25.7",
+        "@babel/helper-replace-supers": "^7.25.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
+        "@babel/traverse": "^7.25.7",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -372,41 +372,41 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
-      "integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.7.tgz",
+      "integrity": "sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.8",
-        "@babel/types": "^7.24.8"
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
-      "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
+      "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
-      "integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
+      "integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-simple-access": "^7.24.7",
-        "@babel/helper-validator-identifier": "^7.24.7",
-        "@babel/traverse": "^7.25.2"
+        "@babel/helper-module-imports": "^7.25.7",
+        "@babel/helper-simple-access": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
+        "@babel/traverse": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -416,35 +416,35 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
-      "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.7.tgz",
+      "integrity": "sha512-VAwcwuYhv/AT+Vfr28c9y6SHzTan1ryqrydSTFGjU0uDJHw3uZ+PduI8plCLkRsDnqK2DMEDmwrOQRsK/Ykjng==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.24.7"
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
-      "integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
+      "integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
-      "integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.7.tgz",
+      "integrity": "sha512-iy8JhqlUW9PtZkd4pHM96v6BdJ66Ba9yWSE4z0W4TvSZwLBPkyDsiIU3ENe4SmrzRBs76F7rQXTy1lYC49n6Lw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.24.8",
-        "@babel/helper-optimise-call-expression": "^7.24.7",
-        "@babel/traverse": "^7.25.0"
+        "@babel/helper-member-expression-to-functions": "^7.25.7",
+        "@babel/helper-optimise-call-expression": "^7.25.7",
+        "@babel/traverse": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -454,53 +454,53 @@
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
-      "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
+      "integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
-      "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.7.tgz",
+      "integrity": "sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.24.7",
-        "@babel/types": "^7.24.7"
+        "@babel/traverse": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
-      "integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
+      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
-      "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
+      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
-      "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
+      "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -520,12 +520,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
-      "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
+      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
         "chalk": "^2.4.2",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
@@ -535,12 +535,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
-      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.8.tgz",
+      "integrity": "sha512-HcttkxzdPucv3nNFmfOOMfFf64KgdJVqm1KaCm25dPGMLElo9nsLvXeJECQg8UzPuBGLyTSA0ZzqCtDSzKTEoQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.6"
+        "@babel/types": "^7.25.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -550,12 +550,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
-      "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.7.tgz",
+      "integrity": "sha512-ruZOnKO+ajVL/MVx+PwNBPOkrnXTXoWMtte1MBpegfCArhqOe3Bj52avVj1huLLxNKYKXYaSxZ2F+woK1ekXfw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -565,12 +565,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.25.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
-      "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.7.tgz",
+      "integrity": "sha512-rR+5FDjpCHqqZN2bzZm18bVYGaejGq5ZkpVCJLXor/+zlSrSoc4KWcHI0URVWjl/68Dyr1uwZUz/1njycEAv9g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.8"
+        "@babel/helper-plugin-utils": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -580,14 +580,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
-      "integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.7.tgz",
+      "integrity": "sha512-L9Gcahi0kKFYXvweO6n0wc3ZG1ChpSFdgG+eV1WYZ3/dGbJK7vvk91FgGgak8YwRgrCuihF8tE/Xg07EkL5COg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.24.8",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-simple-access": "^7.24.7"
+        "@babel/helper-module-transforms": "^7.25.7",
+        "@babel/helper-plugin-utils": "^7.25.7",
+        "@babel/helper-simple-access": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -649,16 +649,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
-      "integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.7.tgz",
+      "integrity": "sha512-VKlgy2vBzj8AmEzunocMun2fF06bsSWV+FvVXohtL6FGve/+L217qhHxRTVGHEDO/YR8IANcjzgJsd04J8ge5Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-create-class-features-plugin": "^7.25.0",
-        "@babel/helper-plugin-utils": "^7.24.8",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/plugin-syntax-typescript": "^7.24.7"
+        "@babel/helper-annotate-as-pure": "^7.25.7",
+        "@babel/helper-create-class-features-plugin": "^7.25.7",
+        "@babel/helper-plugin-utils": "^7.25.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
+        "@babel/plugin-syntax-typescript": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -668,16 +668,16 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
-      "integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.25.7.tgz",
+      "integrity": "sha512-rkkpaXJZOFN45Fb+Gki0c+KMIglk4+zZXOoMJuyEK8y8Kkc8Jd3BDmP7qPsz0zQMJj+UD7EprF+AqAXcILnexw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7",
-        "@babel/helper-validator-option": "^7.24.7",
-        "@babel/plugin-syntax-jsx": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.25.7",
+        "@babel/helper-validator-option": "^7.25.7",
+        "@babel/plugin-syntax-jsx": "^7.25.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.25.7",
+        "@babel/plugin-transform-typescript": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -687,30 +687,30 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
-      "integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
+      "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/parser": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/code-frame": "^7.25.7",
+        "@babel/parser": "^7.25.7",
+        "@babel/types": "^7.25.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
-      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
+      "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.6",
-        "@babel/parser": "^7.25.6",
-        "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.6",
+        "@babel/code-frame": "^7.25.7",
+        "@babel/generator": "^7.25.7",
+        "@babel/parser": "^7.25.7",
+        "@babel/template": "^7.25.7",
+        "@babel/types": "^7.25.7",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -719,13 +719,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
-      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+      "version": "7.25.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.8.tgz",
+      "integrity": "sha512-JWtuCu8VQsMladxVz/P4HzHUGCAwpuqacmowgXFs5XjxIgKuNjnLokQzuVjlTvIzODaDmpjT3oxcC48vyk9EWg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.24.8",
-        "@babel/helper-validator-identifier": "^7.24.7",
+        "@babel/helper-string-parser": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -751,9 +751,9 @@
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.6.2.tgz",
-      "integrity": "sha512-Fq7eWOl1Rcbrfn6jD8FPCj9Auaxdm5nIK5RYOeW7ughnd/rY5AmPg6b+CfsG39ZHdwiwe8lde3q8uR7CF5S0yQ==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.7.1.tgz",
+      "integrity": "sha512-llTrboQYw5H4THfhN4U3qCnSZ1SOJ60ohhz+SzU0ADGtwlc533DtklQP0vSFaQuCPDn3BPpOd1GbbnUtwNjsrw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
@@ -1483,18 +1483,18 @@
       "license": "MIT"
     },
     "node_modules/@iconify-json/ph": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@iconify-json/ph/-/ph-1.2.0.tgz",
-      "integrity": "sha512-013eLpgTmX1lACOuDnkuhC7gRHyYj9w/j8SyDmlyUYvsKQrwdRsv1otcXtwH3DevuDAzSkreeeRsCeez+gTyVA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@iconify-json/ph/-/ph-1.2.1.tgz",
+      "integrity": "sha512-x0DNfwWrS18dbsBYOq3XGiZnGz4CgRyC+YSl/TZvMQiKhIUl1woWqUbMYqqfMNUBzjyk7ulvaRovpRsIlqIf8g==",
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
       }
     },
     "node_modules/@iconify-json/svg-spinners": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@iconify-json/svg-spinners/-/svg-spinners-1.2.0.tgz",
-      "integrity": "sha512-0ov9JMKnqD4p/8aEzSTk+VKdmKZkRWHTqbzCEgKhL+yvpR8B1k3Ak8CO0bt6o+SBV/l8MOqUgFFgdt0xx8tLEw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@iconify-json/svg-spinners/-/svg-spinners-1.2.1.tgz",
+      "integrity": "sha512-QZNA4YzFD2zqdC6nIBJM6WlAGakUCjvMt92Ks1R4XFxkd76Ps3rdiauYWESDRZvNYURAByp2b9cwZarFula65g==",
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -1950,9 +1950,9 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
-      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
+      "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
       "license": "MIT"
     },
     "node_modules/@lezer/css": {
@@ -1987,9 +1987,9 @@
       }
     },
     "node_modules/@lezer/javascript": {
-      "version": "1.4.18",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.18.tgz",
-      "integrity": "sha512-Y8BeHOt4LtcxJgXwadtfSeWPrh0XzklcCHnCVT+vOsxqH4gWmunP2ykX+VVOlM/dusyVyiNfG3lv0f10UK+mgA==",
+      "version": "1.4.19",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.19.tgz",
+      "integrity": "sha512-j44kbR1QL26l6dMunZ1uhKBFteVGLVCBGNUD2sUaMnic+rbTviVuoK0CD1l9FTW31EueWvFFswCKMH7Z+M3JRA==",
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.2.0",
@@ -2148,16 +2148,16 @@
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.0.tgz",
-      "integrity": "sha512-HJOzSX8dQqtsp/3jVxCU3CXEONF7/2jlGAB28oX8TTw1Dz8JYbEI1UcL8355PuLBE41/IRRMvCw7VkiK/jcUOQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.1.tgz",
+      "integrity": "sha512-bg/l7l5QzUjgsh8kjwDFommzAshnUsuVMV5NM56QVCm+7ZckYdd9P/ExR8xG/Oup0OajVxNLaHJ1tb8mXk+nzQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
-        "@radix-ui/react-collapsible": "1.1.0",
+        "@radix-ui/react-collapsible": "1.1.1",
         "@radix-ui/react-collection": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-direction": "1.1.0",
         "@radix-ui/react-id": "1.1.0",
         "@radix-ui/react-primitive": "2.0.0",
@@ -2202,16 +2202,16 @@
       }
     },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.0.tgz",
-      "integrity": "sha512-zQY7Epa8sTL0mq4ajSJpjgn2YmCgyrG7RsQgLp3C0LQVkG7+Tf6Pv1CeNWZLyqMjhdPkBa5Lx7wYBeSu7uCSTA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.1.tgz",
+      "integrity": "sha512-1///SnrfQHJEofLokyczERxQbWfCGQlQ2XsCZMucVs6it+lq9iw4vXy+uDn1edlb58cOZOWSldnfPAYcT4O/Yg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-presence": "1.1.1",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.0"
@@ -2257,6 +2257,21 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz",
@@ -2273,9 +2288,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
-      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.1.tgz",
+      "integrity": "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2288,14 +2303,14 @@
       }
     },
     "node_modules/@radix-ui/react-context-menu": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.1.tgz",
-      "integrity": "sha512-wvMKKIeb3eOrkJ96s722vcidZ+2ZNfcYZWBPRHIB1VWrF+fiF851Io6LX0kmK5wTDQFKdulCCKJk2c3SBaQHvA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.2.tgz",
+      "integrity": "sha512-99EatSTpW+hRYHt7m8wdDlLtkmTovEe8Z/hnxUPV+SKuuNL5HWNhQI4QSdjZqNSgXHay2z4M3Dym73j9p2Gx5Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
-        "@radix-ui/react-menu": "2.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-menu": "2.1.2",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0"
@@ -2316,25 +2331,25 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.1.tgz",
-      "integrity": "sha512-zysS+iU4YP3STKNS6USvFVqI4qqx8EpiwmT5TuCApVEBca+eRCbONi4EgzfNSuVnOXvC5UPHHMjs8RXO6DH9Bg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
+      "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.0",
-        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
         "@radix-ui/react-focus-scope": "1.1.0",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-portal": "1.1.1",
-        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-slot": "1.1.0",
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.7"
+        "react-remove-scroll": "2.6.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2367,9 +2382,9 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.0.tgz",
-      "integrity": "sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.1.tgz",
+      "integrity": "sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
@@ -2394,9 +2409,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.0.tgz",
-      "integrity": "sha512-w6XZNUPVv6xCpZUqb/yN9DL6auvpGX3C/ee6Hdi16v2UUy25HV2Q5bcflsiDyT/g5RwbPQ/GIT1vLkeRb+ITBw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.1.tgz",
+      "integrity": "sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2452,29 +2467,29 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.1.tgz",
-      "integrity": "sha512-oa3mXRRVjHi6DZu/ghuzdylyjaMXLymx83irM7hTxutQbD+7IhPKdMdRHD26Rm+kHRrWcrUkkRPv5pd47a2xFQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.2.tgz",
+      "integrity": "sha512-lZ0R4qR2Al6fZ4yCCZzu/ReTFrylHFxIqy7OezIpWF4bL0o9biKo0pFIvkaew3TyZ9Fy5gYVrR5zCGZBVbO1zg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-collection": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
-        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.0",
-        "@radix-ui/react-focus-guards": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.1",
+        "@radix-ui/react-focus-guards": "1.1.1",
         "@radix-ui/react-focus-scope": "1.1.0",
         "@radix-ui/react-id": "1.1.0",
         "@radix-ui/react-popper": "1.2.0",
-        "@radix-ui/react-portal": "1.1.1",
-        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-portal": "1.1.2",
+        "@radix-ui/react-presence": "1.1.1",
         "@radix-ui/react-primitive": "2.0.0",
         "@radix-ui/react-roving-focus": "1.1.0",
         "@radix-ui/react-slot": "1.1.0",
         "@radix-ui/react-use-callback-ref": "1.1.0",
         "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "2.5.7"
+        "react-remove-scroll": "2.6.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2523,10 +2538,25 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.1.tgz",
-      "integrity": "sha512-A3UtLk85UtqhzFqtoC8Q0KvR2GbXF3mtPgACSazajqq6A41mEQgo53iPzY4i6BwDxlIFqWIhiQ2G729n+2aw/g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.2.tgz",
+      "integrity": "sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.0",
@@ -2548,9 +2578,9 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
-      "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.1.tgz",
+      "integrity": "sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.0",
@@ -2621,6 +2651,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-context": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.0.tgz",
+      "integrity": "sha512-OKrckBy+sMEgYM/sMmqmErVn0kZqrHPJze+Ql3DzYsDDp0hl0L62nx/2122/Bvps1qz645jlcu2tD9lrRSdf8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3082,9 +3127,9 @@
       "license": "MIT"
     },
     "node_modules/@tutorialkit/astro": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tutorialkit/astro/-/astro-1.0.0.tgz",
-      "integrity": "sha512-7O9cLmpMfsyMBqf/Sen8v95eKJJe+QXC670mp572sq48SdQ38sfmX0RbyzspO8o3aIZxryDsx4XXQhu5ecQugw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@tutorialkit/astro/-/astro-1.1.1.tgz",
+      "integrity": "sha512-I3Krq3emy+OWyuDhRFEofmD22OXRtzSe7mXVQmLsZySUigJ7520O1duSE0yxqQaVlK+Y3DSjEAKdPJli8B71iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3094,10 +3139,10 @@
         "@expressive-code/plugin-line-numbers": "^0.35.3",
         "@nanostores/react": "0.7.2",
         "@stackblitz/sdk": "^1.11.0",
-        "@tutorialkit/react": "1.0.0",
-        "@tutorialkit/runtime": "1.0.0",
-        "@tutorialkit/theme": "1.0.0",
-        "@tutorialkit/types": "1.0.0",
+        "@tutorialkit/react": "1.1.1",
+        "@tutorialkit/runtime": "1.1.1",
+        "@tutorialkit/theme": "1.1.1",
+        "@tutorialkit/types": "1.1.1",
         "@types/react": "^18.3.3",
         "@unocss/reset": "^0.62.2",
         "@webcontainer/api": "1.2.4",
@@ -3124,9 +3169,9 @@
       }
     },
     "node_modules/@tutorialkit/react": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tutorialkit/react/-/react-1.0.0.tgz",
-      "integrity": "sha512-1An/A3iu2ThBHyFQsYAl20HLQBN4/Qr6ro8BmcuC52u3djbD5XiNiX6m/9XWpXlnHEVWhrFnU6FyqLUTNHnoUA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@tutorialkit/react/-/react-1.1.1.tgz",
+      "integrity": "sha512-BTsWetKIdOCEfjFJlCIhqMmFMtGkuqD53il/oT5qhY/WGScpq7QAsFN5+uvw7YPbUtwXcJZsoVHtWy03OKNmDw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.16.3",
@@ -3151,8 +3196,8 @@
         "@radix-ui/react-context-menu": "^2.2.1",
         "@radix-ui/react-dialog": "^1.1.1",
         "@replit/codemirror-lang-svelte": "^6.0.0",
-        "@tutorialkit/runtime": "1.0.0",
-        "@tutorialkit/theme": "1.0.0",
+        "@tutorialkit/runtime": "1.1.1",
+        "@tutorialkit/theme": "1.1.1",
         "@webcontainer/api": "1.2.4",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/addon-web-links": "^0.11.0",
@@ -3166,20 +3211,20 @@
       }
     },
     "node_modules/@tutorialkit/runtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tutorialkit/runtime/-/runtime-1.0.0.tgz",
-      "integrity": "sha512-zYZBetgGGicSpnfB0LIS5hnRdSjTdAFBdwVsTLkBuJ14tcU/TOYqF/hwlmMRn0ZxZir0VWXqXPo2MfqAWfUaVw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@tutorialkit/runtime/-/runtime-1.1.1.tgz",
+      "integrity": "sha512-oLjFzIsTTYMlaz3D6lZbv2Ve9Acil44I0K3rGLxtYI1Ay91Ts4AwyCZK8QE/10yb+PxvfDUjox3SVMssbPltRg==",
       "license": "MIT",
       "dependencies": {
-        "@tutorialkit/types": "1.0.0",
+        "@tutorialkit/types": "1.1.1",
         "@webcontainer/api": "1.2.4",
         "nanostores": "^0.10.3"
       }
     },
     "node_modules/@tutorialkit/theme": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tutorialkit/theme/-/theme-1.0.0.tgz",
-      "integrity": "sha512-v2FECefuuezw41w1vQx4UfeV3LH1v6q4YrlouhPtIEikdCX8WkboRw/chv13W8yguM32aJuXAMNnsAlfY5QUsg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@tutorialkit/theme/-/theme-1.1.1.tgz",
+      "integrity": "sha512-9NCCN2g5QAOraacwlG096FOvYLfYxKdfrzA23MSjHe3AUO4BPoml+lN6kqajWPsairH4OR7VPx32dNdD4u7ZVA==",
       "license": "MIT",
       "dependencies": {
         "@iconify-json/ph": "^1.1.13",
@@ -3189,9 +3234,9 @@
       }
     },
     "node_modules/@tutorialkit/types": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@tutorialkit/types/-/types-1.0.0.tgz",
-      "integrity": "sha512-o9+LXAcQgdzI3WERfOVOF+EEdPROsbz6fmwkeQBsvYIfA+E9C86zihc2wCjXzaHer6/dX+sUvjfd453gnpFNtg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@tutorialkit/types/-/types-1.1.1.tgz",
+      "integrity": "sha512-z9N3/3l4Nzw4fW7EEqDhqAj8ouAOq27azYRqnq3CxgIeaFE3O86DPhtkVI7D1fb5vxC+njYc2QjAdCWOPUIErg==",
       "license": "MIT",
       "dependencies": {
         "zod": "3.23.8"
@@ -4771,9 +4816,9 @@
       "license": "ISC"
     },
     "node_modules/confbox": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
-      "integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "license": "MIT"
     },
     "node_modules/consola": {
@@ -5351,9 +5396,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.9.0.tgz",
-      "integrity": "sha512-nCfGxvsQecVLjjYDu35G2F5ls+ArE3FBfhxV0RSiisMaUKqteq5DMBFNRKwMyVj+VqKTNhawt+BV480YCHKFlQ==",
+      "version": "11.11.9",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.11.9.tgz",
+      "integrity": "sha512-XpdZseuCrZehdHGuW22zZt3SF5g6AHJHJi7JwQIigOznW4Jg1n0oGPMJQheMaKLC+0rp5gxUKMRYI6ytd3q4RQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -6198,15 +6243,15 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=6"
       }
     },
     "node_modules/json-schema-traverse": {
@@ -7637,15 +7682,15 @@
       }
     },
     "node_modules/mlly": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.1.tgz",
-      "integrity": "sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.2.tgz",
+      "integrity": "sha512-tN3dvVHYVz4DhSXinXIk7u9syPYaJvio118uomkovAtWBT+RdbP6Lfh/5Lvo519YMmwBafwlh20IPTXIStscpA==",
       "license": "MIT",
       "dependencies": {
-        "acorn": "^8.11.3",
+        "acorn": "^8.12.1",
         "pathe": "^1.1.2",
-        "pkg-types": "^1.1.1",
-        "ufo": "^1.5.3"
+        "pkg-types": "^1.2.0",
+        "ufo": "^1.5.4"
       }
     },
     "node_modules/mrmime": {
@@ -7768,9 +7813,9 @@
       }
     },
     "node_modules/ofetch": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.0.tgz",
-      "integrity": "sha512-MuHgsEhU6zGeX+EMh+8mSMrYTnsqJQQrpM00Q6QHMKNqQ0bKy0B43tk8tL1wg+CnsSTy1kg4Ir2T5Ig6rD+dfQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
+      "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
       "license": "MIT",
       "dependencies": {
         "destr": "^2.0.3",
@@ -7930,9 +7975,9 @@
       }
     },
     "node_modules/package-manager-detector": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.0.tgz",
-      "integrity": "sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.2.tgz",
+      "integrity": "sha512-VgXbyrSNsml4eHWIvxxG/nTL4wgybMTXCV2Un/+yEc3aDKKU6nQBZjbeP3Pl3qm9Qg92X/1ng4ffvCeD/zwHgg==",
       "license": "MIT"
     },
     "node_modules/parse-entities": {
@@ -8078,13 +8123,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.0.tgz",
-      "integrity": "sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
+      "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.1.7",
-        "mlly": "^1.7.1",
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.2",
         "pathe": "^1.1.2"
       }
     },
@@ -8303,12 +8348,12 @@
       }
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz",
-      "integrity": "sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz",
+      "integrity": "sha512-I2U4JVEsQenxDAKaVa3VZ/JeJZe0/2DxPWL8Tj8yLKctQJQiZM52pn/GWFpSp8dftjM3pSAHVJZscAnC/y+ySQ==",
       "license": "MIT",
       "dependencies": {
-        "react-remove-scroll-bar": "^2.3.4",
+        "react-remove-scroll-bar": "^2.3.6",
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.1.0",
         "use-callback-ref": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@tutorialkit/react": "1.0.0",
+    "@tutorialkit/react": "1.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.7.0",
     "@astrojs/react": "^3.6.0",
-    "@tutorialkit/astro": "1.0.0",
-    "@tutorialkit/theme": "1.0.0",
-    "@tutorialkit/types": "1.0.0",
+    "@tutorialkit/astro": "1.1.1",
+    "@tutorialkit/theme": "1.1.1",
+    "@tutorialkit/types": "1.1.1",
     "@types/node": "^20.14.6",
     "@types/react": "^18.3.3",
     "astro": "^4.15.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@tutorialkit/react": "1.1.1",
+    "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/components/LocalStorage.tsx
+++ b/src/components/LocalStorage.tsx
@@ -20,7 +20,6 @@ export default function LocalStorage() {
 
 function setupLocalStorage() {
   const filenames = tutorialStore.documents.get();
-  console.log("filenames", filenames);
   const cleanups: (() => void)[] = [];
 
   for (const filename in filenames) {

--- a/src/components/LocalStorage.tsx
+++ b/src/components/LocalStorage.tsx
@@ -15,7 +15,7 @@ export default function LocalStorage() {
     return () => cleanupRef.current();
   }, []);
 
-  return null;
+  return <></>;
 }
 
 function setupLocalStorage() {

--- a/src/components/Prettier.tsx
+++ b/src/components/Prettier.tsx
@@ -18,7 +18,7 @@ export default function Prettier() {
     return () => cleanupRef.current();
   }, []);
 
-  return null;
+  return <></>;
 }
 
 function setupPrettier() {

--- a/src/components/Prettier.tsx
+++ b/src/components/Prettier.tsx
@@ -26,6 +26,10 @@ function setupPrettier() {
   const cleanups: (() => void)[] = [];
 
   for (const filename in filenames) {
+    if (!filename.endsWith(".ts") && !filename.endsWith(".tsx")) {
+      continue;
+    }
+
     let timeout: NodeJS.Timeout;
 
     const unsubscribe = tutorialStore.onDocumentChanged(filename, (doc) => {

--- a/src/content/tutorial/1-nextjs-conf/1-community-challenges/1-challenge/content.mdx
+++ b/src/content/tutorial/1-nextjs-conf/1-community-challenges/1-challenge/content.mdx
@@ -4,6 +4,9 @@ title: Challenge I
 focus: /app/page.tsx
 ---
 
+import LocalStorage from "@components/LocalStorage";
+import Prettier from "@components/Prettier";
+
 # Challenge I
 
 <LocalStorage client:load />

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,17 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cross-Origin-Embedder-Policy",
+          "value": "require-corp"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Fixes prettier & local storage setup by converting `content.md` to `content.mdx` and adding `import` statements
- Adds header file for Vercel deployment: https://tutorialkit.dev/guides/deployment/#vercel
- Also update TutorialKit to latest

This file is also breaking the navigation in Astro - what's it for?

https://github.com/manovotny/nextjs-conf-community-challenge/blob/bd5092867bd280787b75823b1637a5316534385a/src/middleware.ts#L1-L26

